### PR TITLE
Ensuring public field access to bevy and godot inside of Transform3D

### DIFF
--- a/godot-bevy/src/plugins/core/transforms.rs
+++ b/godot-bevy/src/plugins/core/transforms.rs
@@ -14,8 +14,8 @@ use super::SceneTreeRef;
 
 #[derive(Debug, Component, Default, Copy, Clone)]
 pub struct Transform3D {
-    bevy: bevy::prelude::Transform,
-    godot: godot::prelude::Transform3D,
+    pub bevy: bevy::prelude::Transform,
+    pub godot: godot::prelude::Transform3D,
 }
 
 impl From<BevyTransform> for Transform3D {


### PR DESCRIPTION
In our Transform2D bevy component, the godot field is accessible to
user systems (see [1]), so I strongly suspect the missing pub on
Transform3D fields is just a typo.

[1] https://github.com/dcvz/godot-bevy/blob/main/examples/dodge-the-creeps-2d/rust/src/gameplay/player.rs#L152
