### PR TITLE
Add a cargo runner to all examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,6 +838,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +857,16 @@ checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
 dependencies = [
  "serde",
  "typeid",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1221,6 +1237,12 @@ name = "libm"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a25169bd5913a4b437588a7e3d127cd6e90127b60e0ffbd834a38f1599e016b8"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
@@ -1642,6 +1664,7 @@ dependencies = [
  "fastrand",
  "godot",
  "godot-bevy",
+ "which",
 ]
 
 [[package]]
@@ -1658,6 +1681,20 @@ dependencies = [
  "fastrand",
  "godot",
  "godot-bevy",
+ "which",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1668,6 +1705,7 @@ dependencies = [
  "fastrand",
  "godot",
  "godot-bevy",
+ "which",
 ]
 
 [[package]]
@@ -2123,6 +2161,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2300,6 +2350,12 @@ checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/examples/dodge-the-creeps-2d/rust/Cargo.toml
+++ b/examples/dodge-the-creeps-2d/rust/Cargo.toml
@@ -7,8 +7,13 @@ rust-version = "1.82"
 [lib]
 crate-type = ["cdylib"]
 
+[[bin]]
+path = "../../run_godot.rs"
+name = "dodge_the_creeps"
+
 [dependencies]
 bevy = { version = "0.16", default-features = false }
 fastrand = { version = "2.3.0" }
 godot = "0.2.4"
 godot-bevy = { path = "../../../godot-bevy" }
+which = "7.0.3"

--- a/examples/input-event-demo/README.md
+++ b/examples/input-event-demo/README.md
@@ -71,7 +71,9 @@ Works with Godot's input map system - users can remap controls!
 ## Running This Example
 
 1. **Build**: `cargo build`
-2. **Run**: Open the Godot project and run the scene
+2. **Run**: You can either:
+    1. Open the Godot project and run the scene
+    1. Ensure the godot binary is in your environment's path and then `cargo run`
 3. **Interact**: Try different input methods:
    - Press keys on your keyboard (Space, Escape, Enter)
    - Click mouse buttons and move the mouse

--- a/examples/input-event-demo/rust/Cargo.toml
+++ b/examples/input-event-demo/rust/Cargo.toml
@@ -7,8 +7,13 @@ rust-version = "1.82"
 [lib]
 crate-type = ["cdylib"]
 
+[[bin]]
+path = "../../run_godot.rs"
+name = "input-event-demo"
+
 [dependencies]
 bevy = { version = "0.16", default-features = false }
 fastrand = { version = "2.3.0" }
 godot = "0.2.4"
 godot-bevy = { path = "../../../godot-bevy" }
+which = "7.0.3"

--- a/examples/run_godot.rs
+++ b/examples/run_godot.rs
@@ -1,0 +1,48 @@
+use std::{
+    path::PathBuf,
+    process::{Command, Stdio, exit},
+};
+
+use which::{which, which_in_global};
+
+fn main() -> Result<(), std::io::Error> {
+    let run_dir = format!("{}/../godot", env!("CARGO_MANIFEST_DIR"));
+    println!("run: {run_dir:?}");
+
+    let mut child = Command::new(godot_binary_path())
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .current_dir(&run_dir)
+        .spawn()?;
+
+    let status = child.wait()?;
+    match status.code() {
+        Some(code) => exit(code),
+        None => {
+            println!("Process terminated by signal");
+            exit(255);
+        }
+    }
+}
+
+fn godot_binary_path() -> PathBuf {
+    if let Ok(godot_binary_path) = which("godot") {
+        return godot_binary_path;
+    }
+
+    // Search in some reasonable locations across linux and osx for godot.
+    // Windows is trickier, as I believe the binary name contains the version
+    // of godot, e.g., C:\Program Files\Godot\Godot_v3.4.2-stable_win64.exe
+    let godot_search_paths = "/usr/local/bin:/usr/bin:/bin:/Applications/Godot.app/Contents/MacOS";
+
+    if let Ok(path_it) = which_in_global("godot", Some(godot_search_paths)) {
+        if let Some(godot_binary_path) = path_it.into_iter().next() {
+            return godot_binary_path;
+        }
+    }
+
+    panic!(
+        "Couldn't find the godot binary in your environment's path or in default search locations ({godot_search_paths:?})"
+    );
+}

--- a/examples/timing-test/README.md
+++ b/examples/timing-test/README.md
@@ -51,7 +51,9 @@ app.add_systems(PhysicsUpdate, godot_movement_system);
 ## Running This Example
 
 1. **Build**: `cargo build`
-2. **Run**: Open the Godot project and run the scene
+2. **Run**: You can either:
+    1. Open the Godot project and run the scene
+    1. Ensure the godot binary is in your environment's path and then `cargo run`
 3. **Observe**: Watch the console output for timing patterns
 
 ## Understanding the Output
@@ -71,7 +73,7 @@ This example is particularly useful for:
 
 **No Strong Ordering Guarantees**: `PhysicsUpdate` and the visual frame schedules (`First`, `PreUpdate`, `Update`, etc.) run independently. A physics frame might execute:
 - Before a visual frame starts
-- Between `PreUpdate` and `Update` 
+- Between `PreUpdate` and `Update`
 - After `Last` completes
 - Multiple times between visual frames (if physics rate > visual rate)
 

--- a/examples/timing-test/rust/Cargo.toml
+++ b/examples/timing-test/rust/Cargo.toml
@@ -7,8 +7,13 @@ rust-version = "1.82"
 [lib]
 crate-type = ["cdylib"]
 
+[[bin]]
+path = "../../run_godot.rs"
+name = "timing-test"
+
 [dependencies]
 bevy = { version = "0.16", default-features = false }
 fastrand = { version = "2.3.0" }
 godot = "0.2.4"
 godot-bevy = { path = "../../../godot-bevy" }
+which = "7.0.3"


### PR DESCRIPTION
This makes it just a touch more convenient to run the examples.  

Note: Even with these changes, `cargo run` won't work until you open the projects in Godot _if and only if_ the version of godot that people are running has breaking godot project changes between what's source controlled in our  repo and their local versions, e.g., I run the latest dev snapshot and something about uuids changed between that and 4.4 stable. Once I open the projects in the editor, which triggers the godot project update cycle, cargo run works nicely. I suspect if I ran 4.4 stable, I'd not hit these at all.

Closes #16 
